### PR TITLE
feat: support absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "name": "Hannes Obweger"
     },
     "repository": {
-        "type" : "git",
-        "url" : "https://github.com/obweger/plugin-name-to-package-name.git"
+        "type": "git",
+        "url": "https://github.com/obweger/plugin-name-to-package-name.git"
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -22,14 +22,18 @@
         "dist/!(*test.*)"
     ],
     "devDependencies": {
+        "@types/is-absolute": "^1.0.0",
         "@types/jest": "^25.2.1",
         "jest": "^25.5.4",
         "ts-jest": "^25.4.0",
-        "typescript": "^3.8.3,"
+        "typescript": "^3.8.3"
     },
     "keywords": [
         "plugin",
         "package",
         "eslint"
-    ]
+    ],
+    "dependencies": {
+        "is-absolute": "^1.0.0"
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
+import isAbsolute from 'is-absolute'
+
 export const transform = (pluginName: string, pluginPrefix: string) => {
+    if (isAbsolute(pluginName)) {
+        return pluginName
+    }
     const parts = pluginName.split('/');
     if (parts.length === 1) {
         if (parts[0].startsWith('@')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import isAbsolute from 'is-absolute'
 
 export const transform = (pluginName: string, pluginPrefix: string) => {
-    if (isAbsolute(pluginName)) {
+    if (isAbsolute(pluginName) || pluginName.startsWith('.')) {
         return pluginName
     }
     const parts = pluginName.split('/');

--- a/src/test.ts
+++ b/src/test.ts
@@ -13,4 +13,7 @@ describe('plugin-name-to-package-name', () => {
     test('transforms deeply nested plugin names [theoretical]', () => {
         expect(transform('@foo/bar/baz', 'some-plugin')).toBe('@foo/bar/some-plugin-baz');
     });
+    test('keeps absolute directories', () => {
+        expect(transform('/foo/bar/baz', 'some-plugin')).toBe('/foo/bar/baz');
+    });
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -16,4 +16,10 @@ describe('plugin-name-to-package-name', () => {
     test('keeps absolute directories', () => {
         expect(transform('/foo/bar/baz', 'some-plugin')).toBe('/foo/bar/baz');
     });
+    test('keeps relative directories subpath', () => {
+        expect(transform('./foo', 'some-plugin')).toBe('./foo');
+    });
+    test('keeps relative directories parent path', () => {
+        expect(transform('../foo', 'some-plugin')).toBe('../foo');
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,6 +500,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-absolute@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/is-absolute/-/is-absolute-1.0.0.tgz#d27e9bafca7e7d22eeb51c35634838acaa5129a4"
+  integrity sha512-+ewDHiz0KIw9WCszDwbJM27f9yVQh9BcxdGgyr2GflS6WZE465FGLcBfhaNWa2bnkiEiDj5VSXEPWdmxpOW67w==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1586,6 +1591,14 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
+is-absolute@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
+  integrity sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==
+  dependencies:
+    is-relative "^1.0.0"
+    is-windows "^1.0.1"
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -1695,6 +1708,13 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-relative@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
+  integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
+  dependencies:
+    is-unc-path "^1.0.0"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -1710,7 +1730,14 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
-is-windows@^1.0.2:
+is-unc-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-1.0.0.tgz#d731e8898ed090a12c352ad2eaed5095ad322c9d"
+  integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
+  dependencies:
+    unc-path-regex "^0.1.2"
+
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -3373,6 +3400,11 @@ typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+unc-path-regex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR adds absolute path support. If the passed `pluginName` is absolute (especially nice for testing), it just returns it as-is, otherwise the logic works like before.