### PR TITLE
do not add prefix if it already exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,17 @@ export const transform = (pluginName: string, pluginPrefix: string) => {
         if (parts[0].startsWith('@')) {
             return `${parts[0]}/${pluginPrefix}`;
         } else {
-            return `${pluginPrefix}-${parts[0]}`;
+            if (parts[0].startsWith(`${pluginPrefix}-`)) {
+                return parts[0];
+            } else {
+                return `${pluginPrefix}-${parts[0]}`;
+            }
         }
     } else {
-        const last = parts.splice(parts.length - 1, 1);
+        const last = parts.splice(parts.length - 1, 1)[0];
+        if (last.startsWith(`${pluginPrefix}-`)) {
+            return `${parts.join('/')}/${last}`;
+        }
         return `${parts.join('/')}/${pluginPrefix}-${last}`;
     }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -13,4 +13,16 @@ describe('plugin-name-to-package-name', () => {
     test('transforms deeply nested plugin names [theoretical]', () => {
         expect(transform('@foo/bar/baz', 'some-plugin')).toBe('@foo/bar/some-plugin-baz');
     });
+    test('does not transform plugin names with prefix', () => {
+        expect(transform('some-plugin-foo', 'some-plugin')).toBe('some-plugin-foo');
+    });
+    test('does not transform plugin names with prefix but missing dash', () => {
+        expect(transform('some-pluginfoo', 'some-plugin')).toBe('some-plugin-some-pluginfoo');
+    });
+    test('does not transform plugin names with prefix and scope', () => {
+        expect(transform('@foo/some-plugin-bar', 'some-plugin')).toBe('@foo/some-plugin-bar');
+    });
+    test('does not transform plugin names with prefix and scope but missing dash', () => {
+        expect(transform('@foo/some-pluginbar', 'some-plugin')).toBe('@foo/some-plugin-some-pluginbar');
+    });
 });


### PR DESCRIPTION
The package adds the plugin prefix even if it already is there. This PR fixes it.